### PR TITLE
Create wheel packaging

### DIFF
--- a/GEMS2/GEMS2Python.cxx
+++ b/GEMS2/GEMS2Python.cxx
@@ -51,11 +51,19 @@ PYBIND11_MODULE(GEMS2Python, m) {
             py::arg("numberOfGaussiansPerClass")=py::array_t<int>(),
             py::arg("targetPoints")=py::array_t<double>())
             .def("evaluate_mesh_position", &KvlCostAndGradientCalculator::EvaluateMeshPosition)
+            // Aliases to help with profiling
+            .def("evaluate_mesh_position_a", &KvlCostAndGradientCalculator::EvaluateMeshPosition)
+            .def("evaluate_mesh_position_b", &KvlCostAndGradientCalculator::EvaluateMeshPosition)
+            .def("evaluate_mesh_position_c", &KvlCostAndGradientCalculator::EvaluateMeshPosition)
             ;
 
     py::class_<KvlOptimizer>(m, "KvlOptimizer")
             .def(py::init<const std::string &, const KvlMesh&, const KvlCostAndGradientCalculator&, const std::map<std::string, double> &>())
             .def("step_optimizer", &KvlOptimizer::StepOptimizer)
+            // Aliases to help with profiling
+            .def("step_optimizer_warp", &KvlOptimizer::StepOptimizer)
+            .def("step_optimizer_atlas", &KvlOptimizer::StepOptimizer)
+            .def("step_optimizer_samseg", &KvlOptimizer::StepOptimizer)
             ;
 
     py::class_<KvlMesh>(m, "KvlMesh")
@@ -65,6 +73,13 @@ PYBIND11_MODULE(GEMS2Python, m) {
             .def_property("alphas", &KvlMesh::GetAlphas, &KvlMesh::SetAlphas)
             .def("scale", &KvlMesh::Scale)
             .def("rasterize", &KvlMesh::RasterizeMesh, py::arg("shape"), py::arg("classNumber") = -1)
+            // Aliases to help with profiling
+            .def("rasterize_warp", &KvlMesh::RasterizeMesh, py::arg("shape"), py::arg("classNumber") = -1)
+            .def("rasterize_atlas", &KvlMesh::RasterizeMesh, py::arg("shape"), py::arg("classNumber") = -1)
+            .def("rasterize_1a", &KvlMesh::RasterizeMesh, py::arg("shape"), py::arg("classNumber") = -1)
+            .def("rasterize_1b", &KvlMesh::RasterizeMesh, py::arg("shape"), py::arg("classNumber") = -1)
+            .def("rasterize_2", &KvlMesh::RasterizeMesh, py::arg("shape"), py::arg("classNumber") = -1)
+            .def("rasterize_3", &KvlMesh::RasterizeMesh, py::arg("shape"), py::arg("classNumber") = -1)
             ;
 
     py::class_<KvlMeshCollection>(m, "KvlMeshCollection")

--- a/GEMS2/setup.cfg
+++ b/GEMS2/setup.cfg
@@ -1,0 +1,6 @@
+[bdist_wheel]
+python-tag = py35
+
+[metadata]
+license_file = ../LICENSE
+

--- a/GEMS2/setup.py
+++ b/GEMS2/setup.py
@@ -1,69 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""The setup script."""
 import os
-import re
-import sys
-import platform
-import subprocess
+from setuptools import setup, find_packages, Distribution
 
-from setuptools import setup, Extension
-from setuptools.command.build_ext import build_ext
-from distutils.version import LooseVersion
+class BinaryDistribution(Distribution):
+    def is_pure(self):
+        return False
+    def has_ext_modules(self):
+        return True
 
+def create_init_file():
+    file_path = os.path.join(os.path.dirname(__file__), 'bin','__init__.py')
+    if not os.path.exists(file_path):
+        with open(file_path, 'w'):
+            pass
 
-class CMakeExtension(Extension):
-    def __init__(self, name, sourcedir=''):
-        Extension.__init__(self, name, sources=[])
-        self.sourcedir = os.path.abspath(sourcedir)
-
-
-class CMakeBuild(build_ext):
-    def run(self):
-        try:
-            out = subprocess.check_output(['cmake', '--version'])
-        except OSError:
-            raise RuntimeError("CMake must be installed to build the following extensions: " +
-                               ", ".join(e.name for e in self.extensions))
-
-        if platform.system() == "Windows":
-            cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
-            if cmake_version < '3.1.0':
-                raise RuntimeError("CMake >= 3.1.0 is required on Windows")
-
-        for ext in self.extensions:
-            self.build_extension(ext)
-
-    def build_extension(self, ext):
-        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
-        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-                      '-DPYTHON_EXECUTABLE=' + sys.executable]
-
-        cfg = 'Debug' if self.debug else 'Release'
-        build_args = ['--config', cfg]
-
-        if platform.system() == "Windows":
-            cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
-            if sys.maxsize > 2**32:
-                cmake_args += ['-A', 'x64']
-            build_args += ['--', '/m']
-        else:
-            cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
-            build_args += ['--', '-j2']
-
-        env = os.environ.copy()
-        env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
-                                                              self.distribution.get_version())
-        if not os.path.exists(self.build_temp):
-            os.makedirs(self.build_temp)
-        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
-        subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
+create_init_file()
 
 setup(
+    distclass=BinaryDistribution,
     name='GEMS2Python',
-    version='0.0.1',
-    author='Yujan Shrestha',
-    author_email='yshrestha@innolitics.com',
-    description='Python bindings to GEMS2.',
-    long_description='',
-    ext_modules=[CMakeExtension('GEMS2Python')],
-    cmdclass=dict(build_ext=CMakeBuild),
+    version='0.1.0',
+    description="Python wrapper for GEMS2 C++ tooling",
+    package_dir={'gems2python':'bin'},
+    packages=['gems2python'],
+    package_data={
+        'gems2python':['GEMS2Python.cpython-35m-x86_64-linux-gnu.so'],
+    },
     zip_safe=False,
+    keywords='gems2python samseg gems2 freesurfer',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3.5',
+    ],
 )

--- a/as_python/MANIFEST.in
+++ b/as_python/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst

--- a/as_python/README.rst
+++ b/as_python/README.rst
@@ -1,0 +1,2 @@
+TODO: proper readme
+

--- a/as_python/requirements.txt
+++ b/as_python/requirements.txt
@@ -1,3 +1,4 @@
+gems2python==0.1.0
 numpy==1.13.3
 py==1.5.2
 pytest==3.2.5

--- a/as_python/samseg/Testing/test_arg_parsing.py
+++ b/as_python/samseg/Testing/test_arg_parsing.py
@@ -1,6 +1,6 @@
 import argparse
 
-from as_python.samseg.command_arguments import parse_args
+from samseg.command_arguments import parse_args
 
 
 class MockingParser(argparse.ArgumentParser):

--- a/as_python/samseg/Testing/test_kvl.py
+++ b/as_python/samseg/Testing/test_kvl.py
@@ -1,9 +1,10 @@
-import GEMS2Python
+from gems2python import GEMS2Python
+
 import numpy as np
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_array_almost_equal
 
-from as_python.samseg.kvl import transform_product, voxel_spacing_of_transform, calculate_down_sampling_factors
+from samseg.kvl import transform_product, voxel_spacing_of_transform, calculate_down_sampling_factors
 
 
 def test_transform_product():

--- a/as_python/samseg/Testing/test_run_utilities.py
+++ b/as_python/samseg/Testing/test_run_utilities.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from as_python.samseg.run_utilities import find_or_create_save_path, determine_compression_lookup_table_file_name, \
+from samseg.run_utilities import find_or_create_save_path, determine_compression_lookup_table_file_name, \
     determine_optimization_options, specify_model, Specification
 
 EXPECTED_NAMES = {name for name in [

--- a/as_python/samseg/command_arguments.py
+++ b/as_python/samseg/command_arguments.py
@@ -13,6 +13,7 @@ def parse_args(argv=None, parser=argparse.ArgumentParser()):
     parser.add_argument('--nobrainmask', action='store_true', default=False, help="no initial brain masking based on affine atlas registration")
     parser.add_argument('--diagcovs', action='store_true', default=False, help="use diagonal covariance matrices (only affect multi-contrast case)")
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help="verbose debug output")
+    parser.add_argument('-a', '--atlas_only', action='store_true', default=False, help="register atlas only")
     args = parser.parse_args(args=argv)
     if not args.image_file_names:
         parser.error("must specify at least one input")

--- a/as_python/samseg/dev_utils/compare_test_cases.py
+++ b/as_python/samseg/dev_utils/compare_test_cases.py
@@ -1,10 +1,11 @@
-import GEMS2Python
+from gems2python import GEMS2Python
 
-from as_python.samseg.dev_utils.debug_client import create_part1_inspection_team, \
+
+from samseg.dev_utils.debug_client import create_part1_inspection_team, \
     create_part2_inspection_team, create_part3_inspection_team, create_reduced_alphas_inspection_team, \
     create_optimizer_inspection_team, create_multiresWarp_inspection_team, create_optimizer_exit_inspection_team, \
     create_optimizer_em_exit_inspection_team, create_bias_correction_inspection_team, run_test_cases
-from as_python.samseg.dev_utils.run_samseg_test_case import create_checkpoint_manager
+from samseg.dev_utils.run_samseg_test_case import create_checkpoint_manager
 
 
 def compare_single_case(case_name, case_file_folder, savePath):

--- a/as_python/samseg/dev_utils/compute_dice_measure.py
+++ b/as_python/samseg/dev_utils/compute_dice_measure.py
@@ -1,8 +1,9 @@
 import os
 
-import GEMS2Python
+from gems2python import GEMS2Python
 
-from as_python.samseg.dev_utils.debug_client import run_test_cases, compare_ndarray_dice, create_checkpoint_manager
+
+from samseg.dev_utils.debug_client import run_test_cases, compare_ndarray_dice, create_checkpoint_manager
 
 RESULT_LEAF_NAME = 'crispSegmentation.nii'
 

--- a/as_python/samseg/dev_utils/compute_dice_measure.py
+++ b/as_python/samseg/dev_utils/compute_dice_measure.py
@@ -40,32 +40,24 @@ def dice_compare_test_case(case_name, case_file_folder, save_path, cross_compare
                 print('no data at {0}'.format(matlab_file_path))
 
 def find_gold_image(case_name):
-    gold_dir = os.getenv('GOLD_REFERENCE_DIR')
-    gold_case_dir = os.path.join(gold_dir, case_name)
-    gold_file_path = os.path.join(gold_case_dir, RESULT_LEAF_NAME)
-    if os.path.isfile(gold_file_path):
-        gold_image_buffer = GEMS2Python.KvlImage(gold_file_path).getImageBuffer()
-        return gold_image_buffer, gold_file_path
-    else:
-        return None, gold_file_path
+    return find_image_and_path(os.getenv('GOLD_REFERENCE_DIR'), case_name)
 
 def find_python_image(save_path):
-    python_file_path = os.path.join(save_path, RESULT_LEAF_NAME)
-    if os.path.isfile(python_file_path):
-        python_image_buffer = GEMS2Python.KvlImage(python_file_path).getImageBuffer()
-        return python_image_buffer, python_file_path
-    else:
-        return None, python_file_path
+    return find_image_and_path(save_path)
 
 def find_matlab_image(save_path, case_name):
     matlab_save_path = os.path.join(os.path.dirname(os.path.dirname(save_path)), 'matlab_temp_data')
-    matlab_case_dir = os.path.join(matlab_save_path, case_name)
-    matlab_file_path = os.path.join(matlab_case_dir, RESULT_LEAF_NAME)
-    if os.path.isfile(matlab_file_path):
-        matlab_image_buffer = GEMS2Python.KvlImage(matlab_file_path).getImageBuffer()
-        return matlab_image_buffer, matlab_file_path
+    return find_image_and_path(matlab_save_path, case_name)
+
+def find_image_and_path(case_dir, case_name=None):
+    if case_name:
+        case_dir = os.path.join(case_dir, case_name)
+    file_path = os.path.join(case_dir, RESULT_LEAF_NAME)
+    if os.path.isfile(file_path):
+        image_buffer = GEMS2Python.KvlImage(file_path).getImageBuffer()
+        return image_buffer, file_path
     else:
-        return None, matlab_file_path
+        return None, file_path
 
 
 def simple_dice_compare(case_name, case_file_folder, savePath):

--- a/as_python/samseg/dev_utils/full_cross_compare.py
+++ b/as_python/samseg/dev_utils/full_cross_compare.py
@@ -1,5 +1,5 @@
-from as_python.samseg.dev_utils.compute_dice_measure import dice_compare_test_case
-from as_python.samseg.dev_utils.debug_client import run_test_cases
+from samseg.dev_utils.compute_dice_measure import dice_compare_test_case
+from samseg.dev_utils.debug_client import run_test_cases
 
 
 def full_dice_compare(case_name, case_file_folder, savePath):

--- a/as_python/samseg/dev_utils/measure_and_report.py
+++ b/as_python/samseg/dev_utils/measure_and_report.py
@@ -1,9 +1,9 @@
 import json
 import os
 
-from as_python.samseg.dev_utils.compute_dice_measure import find_gold_image, find_python_image, \
+from samseg.dev_utils.compute_dice_measure import find_gold_image, find_python_image, \
     find_matlab_image
-from as_python.samseg.dev_utils.debug_client import valid_case_folders_and_save_paths, \
+from samseg.dev_utils.debug_client import valid_case_folders_and_save_paths, \
     measure_label_differences, find_testing_dir
 
 

--- a/as_python/samseg/dev_utils/rasterize_mesh.py
+++ b/as_python/samseg/dev_utils/rasterize_mesh.py
@@ -10,8 +10,7 @@ def require_np_array(np_array):
     return np.require(np_array, requirements=['F_CONTIGUOUS', 'ALIGNED'])
 
 
-def rasterize_a_mesh(mesh_collection_file_name, thread_count=1, repeat_count=10):
-    GEMS2Python.setGlobalDefaultNumberOfThreads(thread_count)
+def create_mesh(mesh_collection_file_name=MESH_COLLECTION_NAME):
     scaling = 0.9
     scalingMatrix = np.diag([scaling, scaling, scaling, 1.0])
     initialWorldToWorldTransformMatrix = scalingMatrix
@@ -22,6 +21,11 @@ def rasterize_a_mesh(mesh_collection_file_name, thread_count=1, repeat_count=10)
     mesh_collection.k = K
     mesh_collection.transform(GEMS2Python.KvlTransform(require_np_array(initialWorldToWorldTransformMatrix)))
     mesh = mesh_collection.reference_mesh
+    return mesh
+
+def rasterize_a_mesh(mesh_collection_file_name, thread_count=1, repeat_count=10):
+    mesh = create_mesh(mesh_collection_file_name)
+    GEMS2Python.setGlobalDefaultNumberOfThreads(thread_count)
     imageSize = [200, 200, 200]
     process_timer = ProcessTimer()
     for _ in range(repeat_count):

--- a/as_python/samseg/dev_utils/rasterize_mesh.py
+++ b/as_python/samseg/dev_utils/rasterize_mesh.py
@@ -1,0 +1,62 @@
+import numpy as np
+from gems2python import GEMS2Python
+
+from samseg.process_timer import ProcessTimer
+
+MESH_COLLECTION_NAME = '/home/willy/work/cm_p/innolitics_testing/atlas/20Subjects_smoothing2_down2_smoothingForAffine2/atlasForAffineRegistration.txt.gz'
+
+
+def require_np_array(np_array):
+    return np.require(np_array, requirements=['F_CONTIGUOUS', 'ALIGNED'])
+
+
+def rasterize_a_mesh(mesh_collection_file_name, thread_count=1, repeat_count=10):
+    GEMS2Python.setGlobalDefaultNumberOfThreads(thread_count)
+    scaling = 0.9
+    scalingMatrix = np.diag([scaling, scaling, scaling, 1.0])
+    initialWorldToWorldTransformMatrix = scalingMatrix
+    mesh_collection = GEMS2Python.KvlMeshCollection()
+    mesh_collection.read(mesh_collection_file_name)
+    K = 1e-7
+    K = K / (scaling * scaling * scaling)
+    mesh_collection.k = K
+    mesh_collection.transform(GEMS2Python.KvlTransform(require_np_array(initialWorldToWorldTransformMatrix)))
+    mesh = mesh_collection.reference_mesh
+    imageSize = [200, 200, 200]
+    process_timer = ProcessTimer()
+    for _ in range(repeat_count):
+        priors = mesh.rasterize(imageSize)
+    elapsed_time = process_timer.elapsed_time / repeat_count
+    print(str(elapsed_time))
+    return elapsed_time
+
+
+def full_mesh_test():
+    mesh_collection_file_name = MESH_COLLECTION_NAME
+    results = [rasterize_a_mesh(mesh_collection_file_name, thread_count) for thread_count in range(1, 7)]
+    for index, elapsed_time in enumerate(results):
+        thread_count = 1 + index
+        show_result(thread_count, elapsed_time)
+
+
+def show_result(thread_count, elapsed_time):
+    total_seconds = elapsed_time.total_seconds()
+    work = total_seconds * thread_count
+    productivity = 1.0 / total_seconds
+    thread_productivity = productivity / thread_count
+    print('threads={0}   time={1}   threads*time={2}   throughput={3}   throughput per thread={4}'.format(thread_count,
+                                                                                                          total_seconds,
+                                                                                                          work,
+                                                                                                          productivity,
+                                                                                                          thread_productivity))
+
+
+def profile_test(thread_count):
+    mesh_collection_file_name = MESH_COLLECTION_NAME
+    elapsed_time = rasterize_a_mesh(mesh_collection_file_name, thread_count)
+    show_result(thread_count, elapsed_time)
+
+
+if __name__ == '__main__':
+    # full_mesh_test()
+    profile_test(6)

--- a/as_python/samseg/dev_utils/regression_check.py
+++ b/as_python/samseg/dev_utils/regression_check.py
@@ -1,0 +1,22 @@
+from samseg.dev_utils.compute_dice_measure import find_image_and_path
+from samseg.dev_utils.debug_client import compare_ndarray_dice
+
+
+def compare_results(prior_result_path, current_result_path, case_name):
+    prior_image_buffer, prior_path = find_image_and_path(prior_result_path, case_name)
+    if prior_image_buffer is None:
+        print('no prior file at {0}'.format(prior_path))
+        return
+    current_image_buffer, current_path = find_image_and_path(current_result_path, case_name)
+    if current_image_buffer is None:
+        print('no current file at {0}'.format(current_path))
+        return
+    compare_ndarray_dice(current_image_buffer, prior_image_buffer,
+                         '/'.join((case_name, 'current vs prior')))
+
+
+if __name__ == '__main__':
+    prior_result_path = '/home/willy/work/cm_p/python_temp_data'
+    current_result_path = '/home/willy/work/cm_p/innolitics_testing/buckner40/python_temp_data'
+    case_name = '004'
+    compare_results(prior_result_path, current_result_path, case_name)

--- a/as_python/samseg/dev_utils/run_samseg_test_case.py
+++ b/as_python/samseg/dev_utils/run_samseg_test_case.py
@@ -4,6 +4,7 @@ from samseg.dev_utils.debug_client import create_checkpoint_manager, run_test_ca
 from samseg.run_samseg_ported import run_samseg
 
 USE_CHECKPOINT_MANAGER = False
+THREAD_COUNT = 6
 
 def run_single_full_case(case_name, case_file_folder, savePath):
     image_file_path = os.path.join(case_file_folder, 'orig.mgz')
@@ -13,7 +14,9 @@ def run_single_full_case(case_name, case_file_folder, savePath):
         run_samseg(
             imageFileNames=[image_file_path],
             savePath=savePath,
-            checkpoint_manager=checkpoint_manager
+            checkpoint_manager=checkpoint_manager,
+            numberOfThreads=THREAD_COUNT,
+            atlas_only=False,
         )
     else:
         print("{0} is not a file".format(image_file_path))

--- a/as_python/samseg/dev_utils/run_samseg_test_case.py
+++ b/as_python/samseg/dev_utils/run_samseg_test_case.py
@@ -1,7 +1,7 @@
 import os
 
-from as_python.samseg.dev_utils.debug_client import create_checkpoint_manager, run_test_cases
-from as_python.samseg.run_samseg_ported import run_samseg
+from samseg.dev_utils.debug_client import create_checkpoint_manager, run_test_cases
+from samseg.run_samseg_ported import run_samseg
 
 USE_CHECKPOINT_MANAGER = False
 

--- a/as_python/samseg/dev_utils/time_step_optimizer.py
+++ b/as_python/samseg/dev_utils/time_step_optimizer.py
@@ -1,0 +1,80 @@
+import numpy as np
+from gems2python import GEMS2Python
+
+from samseg.dev_utils.rasterize_mesh import show_result, create_mesh
+from samseg.process_timer import ProcessTimer
+
+
+def require_np_array(np_array):
+    return np.require(np_array, requirements=['F_CONTIGUOUS', 'ALIGNED'])
+
+
+IMAGE_FILE_NAME = '/home/willy/work/cm_m/innolitics_testing/buckner40/004/orig.mgz'
+
+
+def full_optimizer_test():
+    mesh = create_mesh()
+    results = [measure_optimizer_step_time(mesh, thread_count) for thread_count in range(1, 7)]
+    for index, elapsed_time in enumerate(results):
+        thread_count = 1 + index
+        show_result(thread_count, elapsed_time)
+
+
+def measure_optimizer_step_time(mesh=None, thread_count=1, repeat_count=3):
+    GEMS2Python.setGlobalDefaultNumberOfThreads(thread_count)
+    test_parts = make_test_parts(mesh)
+    optimizer = test_parts['optimizer']
+    process_timer = ProcessTimer()
+    for _ in range(repeat_count):
+        minLogLikelihoodTimesPrior, maximalDeformation = optimizer.step_optimizer()
+    elapsed_time = process_timer.elapsed_time / repeat_count
+    print(str(elapsed_time))
+    return elapsed_time
+
+
+
+def make_test_parts(mesh=None):
+    if mesh is None:
+        mesh = create_mesh()
+    image = create_image()
+    calculator = create_calculator(image)
+    optimization_parameters = create_optimization_parameters()
+    optimizer = GEMS2Python.KvlOptimizer(
+        'L-BFGS',
+        mesh,
+        calculator,
+        optimization_parameters
+    )
+    return {
+        'image': image,
+        'calculator': calculator,
+        'mesh': mesh,
+        'optimizer': optimizer,
+    }
+
+
+def create_calculator(image):
+    return GEMS2Python.KvlCostAndGradientCalculator('MutualInformation', [image], 'Affine')
+
+
+def create_image():
+    image_file_name = IMAGE_FILE_NAME
+    return GEMS2Python.KvlImage(image_file_name)
+
+
+def create_optimization_parameters():
+    return {
+        'Verbose': 1.0,
+        'MaximalDeformationStopCriterion': 0.005,
+        'LineSearchMaximalDeformationIntervalStopCriterion':  0.005,
+        'BFGS-MaximumMemoryLength': 12.0  # Affine registration only has 12 DOF
+    }
+
+
+def profile_optimizer_test(thread_count):
+    show_result(thread_count, measure_optimizer_step_time(thread_count=thread_count))
+
+
+if __name__ == '__main__':
+    full_optimizer_test()
+    # profile_optimizer_test(1)

--- a/as_python/samseg/kvl.py
+++ b/as_python/samseg/kvl.py
@@ -1,7 +1,8 @@
 import logging
 import math
 
-import GEMS2Python
+from gems2python import GEMS2Python
+
 import numpy as np
 
 logger = logging.getLogger(__name__)

--- a/as_python/samseg/kvlWarpMesh.py
+++ b/as_python/samseg/kvlWarpMesh.py
@@ -143,7 +143,7 @@ def kvlWarpMesh(sourceMeshCollectionFileName, sourceDeformation, targetMeshColle
         #   % denseDeformation = double( kvlRasterizeAtlasMesh( sourceReferenceMesh, imageSize ) ) / ( 2^16 -1 ) ...
         #   %                               * ( maxDeformation - minDeformation ) + minDeformation;
         #   tmp = kvlRasterizeAtlasMesh( sourceReferenceMesh, imageSize );
-        tmp = sourceReferenceMesh.rasterize(imageSize, -1)
+        tmp = sourceReferenceMesh.rasterize_warp(imageSize, -1)
         #
         #   % Unvisited voxels are marked by zeroes in all three coordinates - except possibly for the origin
         #   % which has all three coordinates zero as its natural state
@@ -332,7 +332,7 @@ def kvlWarpMesh(sourceMeshCollectionFileName, sourceDeformation, targetMeshColle
         #
         #   %
         #   [ minLogLikelihoodTimesPrior, maximalDeformation ] = kvlStepOptimizer( optimizer )
-        minLogLikelihoodTimesPrior, maximalDeformation = optimizer.step_optimizer()
+        minLogLikelihoodTimesPrior, maximalDeformation = optimizer.step_optimizer_warp()
         #   %return
         #   if ( maximalDeformation == 0 )
         #     break;

--- a/as_python/samseg/kvlWarpMesh.py
+++ b/as_python/samseg/kvlWarpMesh.py
@@ -2,12 +2,13 @@ import traceback
 
 from scipy import ndimage
 
-import GEMS2Python
+from gems2python import GEMS2Python
+
 import numpy as np
 import scipy.ndimage
 import scipy.io
 
-from as_python.samseg.dev_utils.debug_client import CheckpointManager, compare_ndarray_closeness
+from samseg.dev_utils.debug_client import CheckpointManager, compare_ndarray_closeness
 
 
 # function [ targetDeformation, averageDistance, maximumDistance ] = kvlWarpMesh( sourceMeshCollectionFileName, sourceDeformation, targetMeshCollectionFileName, showFigures )

--- a/as_python/samseg/main.py
+++ b/as_python/samseg/main.py
@@ -1,0 +1,5 @@
+from samseg.command_arguments import parse_args
+from samseg.run_samseg_ported import run_samseg_from_cmdargs
+
+def samseg_main():
+    run_samseg_from_cmdargs(parse_args())

--- a/as_python/samseg/process_timer.py
+++ b/as_python/samseg/process_timer.py
@@ -10,7 +10,9 @@ class ProcessTimer:
         logger.info(message)
         self.start_time = datetime.datetime.now()
 
+    @property
+    def elapsed_time(self):
+        return datetime.datetime.now() - self.start_time
 
     def mark_time(self, message):
-        elapsed_time = datetime.datetime.now() - self.start_time
-        logger.info('%s:%s', message, str(elapsed_time))
+        logger.info('%s:%s', message, str(self.elapsed_time))

--- a/as_python/samseg/register_atlas_ported.py
+++ b/as_python/samseg/register_atlas_ported.py
@@ -1,8 +1,9 @@
 import logging
+from gems2python import GEMS2Python
+
 import numpy as np
 import scipy.ndimage
 import scipy.io
-import GEMS2Python
 import os
 
 logger = logging.getLogger(__name__)

--- a/as_python/samseg/register_atlas_ported.py
+++ b/as_python/samseg/register_atlas_ported.py
@@ -209,7 +209,7 @@ def samseg_registerAtlas(imageFileName,
 
         calculator = GEMS2Python.KvlCostAndGradientCalculator('MutualInformation', [image], 'Affine')
         #   [ cost gradient ] = kvlEvaluateMeshPosition( calculator, mesh );
-        cost, gradient = calculator.evaluate_mesh_position(mesh)
+        cost, gradient = calculator.evaluate_mesh_position_a(mesh)
         #   if true
         #     %
         #     [ xtmp, ytmp, ztmp ] = ndgrid( 1 : size( imageBuffer, 1 ), ...
@@ -221,7 +221,7 @@ def samseg_registerAtlas(imageFileName,
         centerOfGravityImage = np.array(scipy.ndimage.measurements.center_of_mass(imageBuffer))
 
         #     priors = kvlRasterizeAtlasMesh( mesh, size( imageBuffer ) );
-        priors = mesh.rasterize(imageBuffer.shape)
+        priors = mesh.rasterize_atlas(imageBuffer.shape)
         #     %tmp = sum( priors, 4 );
         #     tmp = sum( priors( :, :, :, 2 : end ), 4 );
         tmp = np.sum(priors[:, :, :, 1:], axis=3)
@@ -237,7 +237,7 @@ def samseg_registerAtlas(imageFileName,
         #     kvlSetMeshNodePositions( mesh, trialNodePositions );
         mesh.points = trialNodePositions
         #     [ trialCost trialGradient ] = kvlEvaluateMeshPosition( calculator, mesh );
-        trialCost, trialGradient = calculator.evaluate_mesh_position(mesh)
+        trialCost, trialGradient = calculator.evaluate_mesh_position_b(mesh)
         #     if ( trialCost >= cost )
         if trialCost >= cost:
             #       % Center of gravity was not a success; revert to what we had before
@@ -311,13 +311,13 @@ def samseg_registerAtlas(imageFileName,
         gradients = []
         #   while truek
         while True:
-            cost, gradient = calculator.evaluate_mesh_position(mesh)
+            cost, gradient = calculator.evaluate_mesh_position_c(mesh)
             logger.info("cost = %f", cost)
             costs.append(cost)
             gradients.append(gradient)
             #     %
             #     [ minLogLikelihoodTimesPrior, maximalDeformation ] = kvlStepOptimizer( optimizer )
-            minLogLikelihoodTimesPrior, maximalDeformation = optimizer.step_optimizer()
+            minLogLikelihoodTimesPrior, maximalDeformation = optimizer.step_optimizer_atlas()
             minLogLikelihoodTimesPriors.append(minLogLikelihoodTimesPrior)
             maximalDeformations.append(maximalDeformation)
             #     %return

--- a/as_python/samseg/run_samseg_ported.py
+++ b/as_python/samseg/run_samseg_ported.py
@@ -1,14 +1,14 @@
 import logging
 import os
 
-from as_python.samseg.command_arguments import parse_args
-from as_python.samseg.kvl_read_compression_lookup_table import kvlReadCompressionLookupTable
-from as_python.samseg.kvl_read_shared_gmm_parameters import kvlReadSharedGMMParameters
-from as_python.samseg.process_timer import ProcessTimer
-from as_python.samseg.register_atlas_ported import samseg_registerAtlas
-from as_python.samseg.run_utilities import find_or_create_save_path, specify_model, determine_optimization_options, \
+from samseg.command_arguments import parse_args
+from samseg.kvl_read_compression_lookup_table import kvlReadCompressionLookupTable
+from samseg.kvl_read_shared_gmm_parameters import kvlReadSharedGMMParameters
+from samseg.process_timer import ProcessTimer
+from samseg.register_atlas_ported import samseg_registerAtlas
+from samseg.run_utilities import find_or_create_save_path, specify_model, determine_optimization_options, \
     find_samseg_data_dir
-from as_python.samseg.samseg_ported import samsegment
+from samseg.samseg_ported import samsegment
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)  # TODO: configurable logging

--- a/as_python/samseg/run_samseg_ported.py
+++ b/as_python/samseg/run_samseg_ported.py
@@ -10,6 +10,8 @@ from samseg.run_utilities import find_or_create_save_path, specify_model, determ
     find_samseg_data_dir
 from gems2python import GEMS2Python
 
+from samseg.samseg_ported import samsegment
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)  # TODO: configurable logging
 
@@ -52,6 +54,7 @@ def run_samseg_from_cmdargs(cmdargs):
     # fprintf('Matlab version %s\n',version);
     #
     verbose = cmdargs.verbose
+    atlas_only = cmdargs.atlas_only
     # savePath = cmdargs.outdir;
     savePath = cmdargs.output
     # numberOfThreads = cmdargs.nthreads;
@@ -85,7 +88,8 @@ def run_samseg_from_cmdargs(cmdargs):
             noBrainMasking,
             useDiagonalCovarianceMatrices,
             verbose,
-            numberOfThreads
+            numberOfThreads,
+            atlas_only
     )
 
 
@@ -97,6 +101,7 @@ def run_samseg(
     useDiagonalCovarianceMatrices=False,
     verbose=False,
     numberOfThreads=None,
+    atlas_only=False,
     checkpoint_manager=None
 ):
     #
@@ -158,6 +163,8 @@ def run_samseg(
         checkpoint_manager
     )
     process_timer.mark_time('registration done')
+    if atlas_only:
+        return
     #
     #
     #

--- a/as_python/samseg/samseg_ported.py
+++ b/as_python/samseg/samseg_ported.py
@@ -1,10 +1,10 @@
 import logging
 
-from as_python.samseg.dev_utils.debug_client import run_test_cases, create_checkpoint_manager, load_starting_fixture
-from as_python.samseg.run_utilities import Specification
-from as_python.samseg.samseg_ported_part1 import samsegment_part1
-from as_python.samseg.samseg_ported_part2 import samsegment_part2
-from as_python.samseg.samseg_ported_part3 import samsegment_part3
+from samseg.dev_utils.debug_client import run_test_cases, create_checkpoint_manager, load_starting_fixture
+from samseg.run_utilities import Specification
+from samseg.samseg_ported_part1 import samsegment_part1
+from samseg.samseg_ported_part2 import samsegment_part2
+from samseg.samseg_ported_part3 import samsegment_part3
 
 logger = logging.getLogger(__name__)
 

--- a/as_python/samseg/samseg_ported_part1.py
+++ b/as_python/samseg/samseg_ported_part1.py
@@ -2,12 +2,13 @@ import math
 from functools import reduce
 from operator import mul
 
-import GEMS2Python
+from gems2python import GEMS2Python
+
 import numpy as np
 
-from as_python.samseg.dev_utils.debug_client import create_checkpoint_manager, run_test_cases, \
+from samseg.dev_utils.debug_client import create_checkpoint_manager, run_test_cases, \
     create_part1_inspection_team, load_starting_fixture
-from as_python.samseg.kvl_merge_alphas import kvlMergeAlphas
+from samseg.kvl_merge_alphas import kvlMergeAlphas
 
 
 def samsegment_part1(

--- a/as_python/samseg/samseg_ported_part1.py
+++ b/as_python/samseg/samseg_ported_part1.py
@@ -122,7 +122,7 @@ def samsegment_part1(
     # labelNumber = 0; % background label
     labelNumber = 0
     # backgroundPrior = kvlRasterizeAtlasMesh( mesh, imageSize, labelNumber ); % Volume with background probs
-    backgroundPrior = mesh.rasterize(imageSize, labelNumber)
+    backgroundPrior = mesh.rasterize_1a(imageSize, labelNumber)
     # if 1
     #   % Threshold background prior at 0.5 - this helps for atlases built from imperfect (i.e., automatic)
     #   % segmentations, whereas background areas don't have zero probability for non-background structures
@@ -173,7 +173,7 @@ def samsegment_part1(
     # kvlSetAlphasInMeshNodes( mesh, areaCoveredAlphas );
     mesh.alphas = areaCoveredAlphas  # temporary replacement of alphas
     # areaCoveredByMesh = kvlRasterizeAtlasMesh( mesh, imageSize, 1 );
-    areaCoveredByMesh = mesh.rasterize(imageSize, 1)
+    areaCoveredByMesh = mesh.rasterize_1b(imageSize, 1)
     # kvlSetAlphasInMeshNodes( mesh, alphas );
     mesh.alphas = alphas  # restore alphas
     # brainMask = brainMask & ( areaCoveredByMesh > 0 );

--- a/as_python/samseg/samseg_ported_part2.py
+++ b/as_python/samseg/samseg_ported_part2.py
@@ -218,7 +218,7 @@ def samsegment_part2(
             #
             #     % Get the priors at the current mesh position
             #     tmp = reshape( kvlRasterizeAtlasMesh( mesh, downSampledImageSize ), [ prod( downSampledImageSize ) numberOfClasses ] );
-            tmp = mesh.rasterize(downSampledImageSize, -1)
+            tmp = mesh.rasterize_2(downSampledImageSize, -1)
             #     priors( : ) = double( tmp( downSampledMaskIndices, : ) ) / 65535;
             priors = tmp[downSampledMaskIndices] / 65535
             #
@@ -728,7 +728,7 @@ def samsegment_part2(
                 #       %
                 #       stepStartTime = tic;
                 #       [ minLogLikelihoodTimesDeformationPrior, maximalDeformation ] = kvlStepOptimizer( optimizer );
-                minLogLikelihoodTimesDeformationPrior, maximalDeformation = optimizer.step_optimizer()
+                minLogLikelihoodTimesDeformationPrior, maximalDeformation = optimizer.step_optimizer_samseg()
                 #       disp( [ 'maximalDeformation ' num2str( maximalDeformation ) ' took ' num2str( toc( stepStartTime ) ) ' sec' ] )
                 print("maximalDeformation={} minLogLikelihood={}".format(maximalDeformation,
                                                                          minLogLikelihoodTimesDeformationPrior))

--- a/as_python/samseg/samseg_ported_part2.py
+++ b/as_python/samseg/samseg_ported_part2.py
@@ -1,15 +1,16 @@
 import logging
 
-import GEMS2Python
+from gems2python import GEMS2Python
+
 import numpy as np
 import scipy.io
 
-from as_python.samseg.bias_correction import backprojectKroneckerProductBasisFunctions, \
+from samseg.bias_correction import backprojectKroneckerProductBasisFunctions, \
     projectKroneckerProductBasisFunctions, computePrecisionOfKroneckerProductBasisFunctions
-from as_python.samseg.dev_utils.debug_client import create_part2_inspection_team, run_test_cases, \
+from samseg.dev_utils.debug_client import create_part2_inspection_team, run_test_cases, \
     create_checkpoint_manager, load_starting_fixture
-from as_python.samseg.kvlWarpMesh import kvlWarpMesh
-from as_python.samseg.kvl_merge_alphas import kvlMergeAlphas
+from samseg.kvlWarpMesh import kvlWarpMesh
+from samseg.kvl_merge_alphas import kvlMergeAlphas
 
 logger = logging.getLogger(__name__)
 

--- a/as_python/samseg/samseg_ported_part3.py
+++ b/as_python/samseg/samseg_ported_part3.py
@@ -1,12 +1,13 @@
 import os
 
-import GEMS2Python
+from gems2python import GEMS2Python
+
 import numpy as np
 
-from as_python.samseg.bias_correction import backprojectKroneckerProductBasisFunctions
-from as_python.samseg.dev_utils.debug_client import run_test_cases, create_checkpoint_manager, \
+from samseg.bias_correction import backprojectKroneckerProductBasisFunctions
+from samseg.dev_utils.debug_client import run_test_cases, create_checkpoint_manager, \
     create_part3_inspection_team, load_starting_fixture
-from as_python.samseg.kvlWarpMesh import kvlWarpMesh
+from samseg.kvlWarpMesh import kvlWarpMesh
 
 
 eps = np.finfo(float).eps

--- a/as_python/samseg/samseg_ported_part3.py
+++ b/as_python/samseg/samseg_ported_part3.py
@@ -152,7 +152,7 @@ def samsegment_part3(
     # data = reshape( biasCorrectedImageBuffers, [ prod( imageSize ) numberOfContrasts ] );
     data = biasCorrectedImageBuffers
     # priors = kvlRasterizeAtlasMesh( mesh, imageSize );
-    priors = mesh.rasterize(imageSize, -1)
+    priors = mesh.rasterize_3(imageSize, -1)
     # priors = reshape( priors, [ prod( imageSize ) numberOfStructures ] );
     # NOT GOING TO RESHAPE, WILL USE MASK INDEXING
     #

--- a/as_python/setup.cfg
+++ b/as_python/setup.cfg
@@ -1,0 +1,6 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+# Use license from containing freesurfer project
+license_file = ../LICENSE

--- a/as_python/setup.py
+++ b/as_python/setup.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import io
+import os
+
+from setuptools import setup, find_packages
+
+# Package meta-data.
+NAME = 'samseg'
+DESCRIPTION = 'GEMS2 Samseg.'
+URL = 'https://github.com/innolitics/freesurfer'
+EMAIL = 'wmills@innolitics.com, yshrestha@innolitics.com'
+AUTHOR = 'William Mills, Yujan Shrestha'
+VERSION = '0.1.0'  # TODO look at bumpversion or versioneer to maintain this
+
+# TODO: What packages are required for this module to be executed?
+REQUIRED = [
+    'numpy >= 1.13.3',
+    'scipy >= 1.0.0',
+    'gems2python',
+]
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+with io.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
+    long_description = '\n' + f.read()
+
+our_packages = find_packages(include=['samseg', 'samseg.dev_utils'])
+
+setup(
+    name=NAME,
+    version=VERSION,
+    description=DESCRIPTION,
+    long_description=long_description,
+    author=AUTHOR,
+    author_email=EMAIL,
+    url=URL,
+    packages=our_packages,
+    install_requires=REQUIRED,
+    include_package_data=True,
+    classifiers=[
+        # Trove classifiers
+        # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: Implementation :: CPython',
+    ],
+    entry_points={
+        'console_scripts': [
+            'run_samseg = samseg.main:samseg_main',
+        ]
+    }
+    # $ setup.py publish support.
+    # cmdclass={
+    #     'upload': UploadCommand,
+    # },
+)

--- a/matlab/samseg/rasterize_mesh.m
+++ b/matlab/samseg/rasterize_mesh.m
@@ -1,0 +1,24 @@
+meshCollectionFileName = '/home/willy/work/cm_p/innolitics_testing/atlas/20Subjects_smoothing2_down2_smoothingForAffine2/atlasForAffineRegistration.txt.gz';
+scaling = 0.9 * ones( 1, 3 );
+scalingMatrix = diag( [ scaling 1 ] );
+initialWorldToWorldTransformMatrix = scalingMatrix;
+K = 1e-7;
+K = K / (0.9 * 0.9 * 0.9);
+meshCollection = kvlReadMeshCollection( meshCollectionFileName, ...
+                                        kvlCreateTransform( initialWorldToWorldTransformMatrix), ...
+                                        K  );
+mesh = kvlGetMesh( meshCollection, -1 );
+imageSize = [200, 200, 200];
+
+repeatCount = 10;
+for thread_count = 1: 6
+    kvlSetMaximumNumberOfThreads( thread_count );
+    startingTime = tic;
+    for i = 1: repeatCount
+        priors = kvlRasterizeAtlasMesh( mesh, imageSize );
+    end
+    elapsedTime = toc(startingTime) / repeatCount;
+    productivity = 1.0 / elapsedTime;
+    thread_productivity = productivity / thread_count;
+    fprintf('threads=%d time = %f thread_throughput=%f\n', thread_count, elapsedTime,thread_productivity);
+end

--- a/matlab/samseg/time_optimizer_step.m
+++ b/matlab/samseg/time_optimizer_step.m
@@ -1,0 +1,38 @@
+meshCollectionFileName = '/home/willy/work/cm_m/innolitics_testing/atlas/20Subjects_smoothing2_down2_smoothingForAffine2/atlasForAffineRegistration.txt.gz';
+imageFileName = '/home/willy/work/cm_m/innolitics_testing/buckner40/004/orig.mgz';
+scaling = 0.9 * ones( 1, 3 );
+scalingMatrix = diag( [ scaling 1 ] );
+initialWorldToWorldTransformMatrix = scalingMatrix;
+K = 1e-7;
+K = K / (0.9 * 0.9 * 0.9);
+meshCollection = kvlReadMeshCollection( meshCollectionFileName, ...
+                                        kvlCreateTransform( initialWorldToWorldTransformMatrix), ...
+                                        K  );
+mesh = kvlGetMesh( meshCollection, -1 );
+repeatCount = 3;
+for thread_count = 1: 6
+    kvlSetMaximumNumberOfThreads( thread_count );
+
+    [ image, imageToWorldTransform ] = kvlReadImage( imageFileName );
+  calculator = kvlGetCostAndGradientCalculator( 'MutualInformation', ...
+                                                image, 'Affine' );
+
+  maximalDeformationStopCriterion = 0.005; % Measured in voxels
+  lineSearchMaximalDeformationIntervalStopCriterion = maximalDeformationStopCriterion; % Doesn't seem to matter very much
+  optimizerType = 'L-BFGS';
+  optimizer = kvlGetOptimizer( optimizerType, mesh, calculator, ...
+                                  'Verbose', 1, ...
+                                  'MaximalDeformationStopCriterion', maximalDeformationStopCriterion, ...
+                                  'LineSearchMaximalDeformationIntervalStopCriterion', ...
+                                  lineSearchMaximalDeformationIntervalStopCriterion, ...
+                                  'BFGS-MaximumMemoryLength', 12 ); % Affine registration only has 12 DOF
+
+    startingTime = tic;
+    for i = 1: repeatCount
+        [ minLogLikelihoodTimesPrior, maximalDeformation ] = kvlStepOptimizer( optimizer )
+    end
+    elapsedTime = toc(startingTime) / repeatCount;
+    productivity = 1.0 / elapsedTime;
+    thread_productivity = productivity / thread_count;
+    fprintf('threads=%d time = %f thread_throughput=%f\n', thread_count, elapsedTime,thread_productivity);
+end


### PR DESCRIPTION
as_python:
Logically restructures with samseg as the package. Previously as_python was the package. This
This changes the imports but not the actual file locations. 
`import as_python.samseg.module` --> `import samseg.module`.
With `.../freesurfer/as_python` as current directory, running the command `python setup.py bdist_wheel` constructs a pure python wheel with a `run_samseg` entry point.
 
GEMS2:
Currently only validated for ubuntu 16.04 build.
Set the current directory to `.../freesurfer/as_python`. If the GEMS2Python library has been built and is sitting in `.../freesurfer/GEMS2/bin` then `python setup.py bdist_wheel` will create a valid ubuntu wheel.

At this point the two wheels can be used on any ubuntu 16.04 and installed via `pip install [wheel]`. Install the GEMS2Python wheel first.

